### PR TITLE
Added button to browse for JSON file + print process stdout into a textview

### DIFF
--- a/app/src/main/java/com/osvr/android/utils/OSVRFileExtractor.java
+++ b/app/src/main/java/com/osvr/android/utils/OSVRFileExtractor.java
@@ -24,6 +24,9 @@
  */
 package com.osvr.android.utils;
 
+import android.content.ContextWrapper;
+import android.util.Log;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -33,9 +36,6 @@ import java.util.Enumeration;
 import java.util.Vector;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import android.content.ContextWrapper;
-import android.util.Log;
 
 public class OSVRFileExtractor {
     private final static String ZIP_FILTER = "assets";
@@ -68,7 +68,7 @@ public class OSVRFileExtractor {
         }
     }
 
-    private static String getAppRoot(ContextWrapper context) {
+    public static String getAppRoot(ContextWrapper context) {
         return "/data/data/" + context.getPackageName() + "/files";
     }
 

--- a/app/src/main/java/com/osvr/serverlauncher/MainActivity.java
+++ b/app/src/main/java/com/osvr/serverlauncher/MainActivity.java
@@ -1,23 +1,47 @@
 package com.osvr.serverlauncher;
 
 import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.ScrollView;
+import android.widget.TextView;
 
 import com.osvr.android.utils.OSVRFileExtractor;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.channels.FileChannel;
 import java.util.Map;
 
 public class MainActivity extends Activity {
 
     private Process process;
 
+
+    private static final int RQS_GET_JSON = 1;
+
     final String serverBin = "/data/data/com.osvr.serverlauncher/files/bin/osvr_server";
     final String serverDir = "/data/data/com.osvr.serverlauncher/files/bin";
+
+    Button btnDefaultLaunch, btnJsonLaunch;
+    TextView textView;
+    ScrollView scrollView;
 
     protected void doChmod() {
         String[] args = {"chmod", "775", serverBin};
@@ -26,9 +50,9 @@ public class MainActivity extends Activity {
         try {
             Process chmodProcess = processBuilder.start();
             chmodProcess.waitFor();
-        } catch(IOException ex) {
+        } catch (IOException ex) {
             Log.e("com.OSVR", "Error when starting chmod: " + ex.getMessage());
-        } catch(InterruptedException ex) {
+        } catch (InterruptedException ex) {
             Log.e("com.OSVR", "Error when starting process: " + ex.getMessage());
         }
     }
@@ -38,28 +62,22 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        try {
-            OSVRFileExtractor.extractFiles(this);
-            doChmod();
-            String[] args = {serverBin};
-            //String[] args = {"/system/bin/ls", "/data/local/tmp/osvr/bin"};
-            ProcessBuilder processBuilder = new ProcessBuilder(args)
-                    .directory(new File(serverDir));
+        textView = (TextView) findViewById(R.id.hello_world);
+        scrollView = (ScrollView) findViewById(R.id.scrollview);
+        btnDefaultLaunch = (Button) findViewById(R.id.defaultlaunch);
+        btnJsonLaunch = (Button) findViewById(R.id.jsonlaunch);
 
-            Map<String, String> environment = processBuilder.environment();
-            environment.put("LD_LIBRARY_PATH", "/data/data/com.osvr.serverlauncher/files/lib");
+        btnDefaultLaunch.setOnClickListener(btnDefaultLaunchOnClickListener);
+        btnJsonLaunch.setOnClickListener(btnJsonLaunchOnClickListener);
 
-            process = processBuilder.start();
-
-        } catch(IOException ex) {
-            Log.e("com.OSVR", "Error when starting process: " + ex.getMessage());
-        }
+        OSVRFileExtractor.extractFiles(this);
+        doChmod();
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if(null != process) {
+        if (null != process) {
             process.destroy();
         }
     }
@@ -84,5 +102,180 @@ public class MainActivity extends Activity {
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void startServer(String[] myArgs) {
+        ServerTask mTask = new ServerTask();
+        mTask.execute(myArgs);
+
+    }
+
+    OnClickListener btnDefaultLaunchOnClickListener =
+            new OnClickListener() {
+
+                @Override
+                public void onClick(View v) {
+                    String[] args = {};
+                    startServer(args);
+                }
+
+            };
+
+
+    OnClickListener btnJsonLaunchOnClickListener =
+            new OnClickListener() {
+
+                @Override
+                public void onClick(View v) {
+                    Intent intent = new Intent();
+                    intent.setAction(Intent.ACTION_GET_CONTENT);
+                    intent.addCategory(Intent.CATEGORY_OPENABLE);
+                    intent.setType("*/*");
+
+
+                    startActivityForResult(intent, RQS_GET_JSON);
+                }
+
+            };
+
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == Activity.RESULT_OK) {
+
+
+            if (requestCode == RQS_GET_JSON) {
+
+                Uri content_describer = data.getData();
+                String src = content_describer.getPath();
+                Log.d("com.OSVR", src);
+
+                File source = new File(src);
+
+
+                String appRoot = OSVRFileExtractor.getAppRoot(this);
+
+
+                File outputFile = new File(appRoot, "bin/temp.json");
+                outputFile.getParentFile().mkdirs();
+
+                Log.d("com.OSVR", outputFile.getAbsolutePath());
+
+                //copy files
+                try {
+                    FileInputStream in = (FileInputStream) getContentResolver().openInputStream(data.getData());
+                    FileOutputStream out = new FileOutputStream(outputFile);
+                    FileChannel inChannel = in.getChannel();
+                    FileChannel outChannel = out.getChannel();
+                    inChannel.transferTo(0, inChannel.size(), outChannel);
+                    in.close();
+                    out.close();
+
+                    String[] args = {"temp.json"};
+                    startServer(args);
+
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+
+            }
+        }
+    }
+
+
+    class ServerTask extends AsyncTask<String, Void, Void> {
+        PipedOutputStream mPOut;
+        PipedInputStream mPIn;
+        LineNumberReader mReader;
+
+        @Override
+        protected void onPreExecute() {
+            mPOut = new PipedOutputStream();
+            try {
+                mPIn = new PipedInputStream(mPOut);
+                mReader = new LineNumberReader(new InputStreamReader(mPIn));
+            } catch (IOException e) {
+                cancel(true);
+            }
+
+        }
+
+        public void stop() {
+            Process p = process;
+            if (p != null) {
+                p.destroy();
+            }
+            cancel(true);
+        }
+
+        @Override
+        protected Void doInBackground(String... params) {
+            try {
+
+                String[] defaultArgs = {serverBin};
+
+                int len1 = defaultArgs.length;
+                int len2 = params.length;
+                String[] args = new String[len1 + len2];
+                System.arraycopy(defaultArgs, 0, args, 0, len1);
+                System.arraycopy(params, 0, args, len1, len2);
+
+                ProcessBuilder processBuilder = new ProcessBuilder(args)
+                        .directory(new File(serverDir));
+
+                Map<String, String> environment = processBuilder.environment();
+                environment.put("LD_LIBRARY_PATH", "/data/data/com.osvr.serverlauncher/files/lib");
+
+                process = processBuilder.start();
+
+                try {
+                    InputStream in = process.getInputStream();
+                    OutputStream out = process.getOutputStream();
+                    byte[] buffer = new byte[1024];
+                    int count;
+
+                    // in -> buffer -> mPOut -> mReader -> 1 line of ping information to parse
+                    while ((count = in.read(buffer)) != -1) {
+                        mPOut.write(buffer, 0, count);
+                        publishProgress();
+                    }
+                    out.close();
+                    in.close();
+                    mPOut.close();
+                    mPIn.close();
+                } finally {
+                    process.destroy();
+                    process = null;
+                }
+            } catch (IOException e) {
+                Log.e("com.OSVR", "Error when starting process: " + e.getMessage());
+            }
+            return null;
+        }
+
+        @Override
+        protected void onProgressUpdate(Void... values) {
+            try {
+                // Is a line ready to read from the "ping" command?
+                while (mReader.ready()) {
+                    // This just displays the output, you should typically parse it I guess.
+                    textView.setText(textView.getText() + "\n" + mReader.readLine());
+
+                    scrollView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            // This method works but animates the scrolling
+                            // which looks weird on first load
+                            // scroll_view.fullScroll(View.FOCUS_DOWN);
+
+                            // This method works even better because there are no animations.
+                            scrollView.scrollTo(0, scrollView.getBottom());
+                        }
+                    });
+                }
+            } catch (IOException t) {
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,12 +1,37 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivity">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:orientation="vertical"
+    tools:context="com.osvr.serverlauncher.MainActivity">
 
-    <TextView android:text="@string/hello_world" android:layout_width="wrap_content"
+    <Button
+        android:id="@+id/defaultlaunch"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/hello_world" />
+        android:text="@string/defaultlaunch" />
 
-</RelativeLayout>
+
+    <Button
+            android:id="@+id/jsonlaunch"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/jsonlaunch" />
+
+
+    <ScrollView
+        android:id="@+id/scrollview"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="vertical"
+        android:fillViewport="true">
+
+        <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/hello_world" />
+
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="app_name">OSVR Server Launcher</string>
 
+
+    <string name="defaultlaunch">Launch with default config</string>
+    <string name="jsonlaunch">Browse config</string>
+
     <string name="hello_world">The OSVR server started. Wait a little, then launch your app.</string>
     <string name="action_settings">Settings</string>
 </resources>


### PR DESCRIPTION
I'm currently working on a project that needs to access OSVR tracking data on a PC server from an Android OSVR app. The only way to do it is to use the shell with root access to start the osvr_server on Android with a custom json file.

I added the option to browse for a JSON config in the server launcher to provide a more straightforward way to do that.

Also, I made the process stdout print in a textview for simpler debugging.

My fork does not use code from the auto-launching branch, but it could be added in it.
